### PR TITLE
Track length can be a float

### DIFF
--- a/mosbot/query.py
+++ b/mosbot/query.py
@@ -136,7 +136,7 @@ async def save_track(*, track_dict: dict, conn=None) -> Optional[dict]:
     :return: None if it failed, the updated track if not
     """
     assert track_dict
-    assert isinstance(track_dict.get('length'), int)
+    assert isinstance(track_dict.get('length'), (int, float))
     assert isinstance(track_dict.get('origin'), (str, Origin))
     assert isinstance(track_dict.get('extid'), str)
     assert isinstance(track_dict.get('name'), str)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -229,8 +229,16 @@ async def test_get_track(db_conn, track_generator, track_dict, raises_exception)
     ({'extid': 'ab12', 'origin': (1, 2), 'length': 120, 'name': 'One name'}, AssertionError),
     ({'extid': 'ab12', 'origin': 'youtube', 'length': 120, 'name': 12345}, AssertionError),
     ({}, AssertionError),
-], ids=['good_with_string', 'good_with_enum', 'good_with_float', 'bad_with_int', 'bad_with_string', 'bad_with_tuple', 'bad_with_int_name',
-        'bad_no_data'])
+], ids=[
+    'good_with_string',
+    'good_with_enum',
+    'good_with_float',
+    'bad_with_int',
+    'bad_with_string',
+    'bad_with_tuple',
+    'bad_with_int_name',
+    'bad_no_data'
+])
 @pytest.mark.asyncio
 async def test_save_track(db_conn, track_dict, raises_exception):
     if raises_exception:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -223,12 +223,13 @@ async def test_get_track(db_conn, track_generator, track_dict, raises_exception)
 @pytest.mark.parametrize("track_dict, raises_exception", [
     ({'extid': 'ab12', 'origin': 'youtube', 'length': 120, 'name': 'One name'}, None),
     ({'extid': 'ab12', 'origin': Origin.youtube, 'length': 120, 'name': 'One name'}, None),
+    ({'extid': 'ab12', 'origin': Origin.youtube, 'length': 120.0, 'name': 'One name'}, None),
     ({'extid': 12345, 'origin': 'youtube', 'length': 120, 'name': 'One name'}, AssertionError),
     ({'extid': 'ab12', 'origin': 'youtube', 'length': '120', 'name': 'One name'}, AssertionError),
     ({'extid': 'ab12', 'origin': (1, 2), 'length': 120, 'name': 'One name'}, AssertionError),
     ({'extid': 'ab12', 'origin': 'youtube', 'length': 120, 'name': 12345}, AssertionError),
     ({}, AssertionError),
-], ids=['good_with_string', 'good_with_enum', 'bad_with_int', 'bad_with_string', 'bad_with_tuple', 'bad_with_int_name',
+], ids=['good_with_string', 'good_with_enum', 'good_with_float', 'bad_with_int', 'bad_with_string', 'bad_with_tuple', 'bad_with_int_name',
         'bad_no_data'])
 @pytest.mark.asyncio
 async def test_save_track(db_conn, track_dict, raises_exception):


### PR DESCRIPTION
Current assertion fails because track length is displayed as a float value

Example:

`{'length': 491.0, 'origin': <Origin.youtube: 1>, 'extid': '84bFEZsOItA', 'name': 'The Dark Knight - Epic Orchestral Cover'}`